### PR TITLE
added `allNotesOff` to embind.cpp to prevent runtime error

### DIFF
--- a/wasm/open303.embind.cpp
+++ b/wasm/open303.embind.cpp
@@ -40,6 +40,7 @@ EMSCRIPTEN_BINDINGS(Open303) {
 			.function("slideToNote", &Open303::slideToNote)
 			.function("releaseNote", &Open303::noteOn)
 			.function("noteOn", &Open303::noteOn)
+			.function("allNotesOff", &Open303::allNotesOff)
 			.function("setPitchBend", &Open303::setPitchBend)
 		;
 };


### PR DESCRIPTION
the lack of the allNotesOff method was blowing up the sema-engine with rubber duckling 

could you merge please?